### PR TITLE
fix: permission denied versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
+
 jobs:
   bump_version:
     runs-on: ubuntu-latest
@@ -12,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ env.GITHUB_TOKEN }}
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:


### PR DESCRIPTION
CI was encountering a permission denied error when trying to push during the versioning workflow.

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>