### PR TITLE
fix: versioning ci

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -3,7 +3,7 @@ name: continuous_release
 on:
   push:
     branches: ["**"]
-    tags: ["v*"]
+    tags: ["v**"]
 
 env:
   GITHUB_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
@@ -25,9 +25,15 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
       - name: Bump Version
+        if: startsWith(github.ref, 'refs/heads/')
         run: make bump
         env:
           BUILD_VERSION: v${{ steps.gitversion.outputs.MajorMinorPatch }}-rc${{ steps.gitversion.outputs.CommitsSinceVersionSource }}
+      - name: Bump Version for release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: make bump
+        env:
+          BUILD_VERSION: v${{ steps.gitversion.outputs.MajorMinorPatch }}
       - name: Commit Version Bump if on main
         if: github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v7


### PR DESCRIPTION
The tag ci is not triggering and the version had an `-rc` part even if it was a release

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>